### PR TITLE
Added a keyword argument to `normalize` which makes it possible to override the default normalizer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,18 @@ from email_normalizer import normalize
 # returns alicetestemail@gmail.com
 normalize('Alice.Test.Email+2e16f5091e4c9a1fecd712ad1e019569@gmail.com')
 ```
+
+The default normalizer can be overridden if you want to specify your own behavior.
+
+```python
+from email_normalizer import normalize, BaseNormalizer
+
+class MyNormalizer(BaseNormalizer):
+    @classmethod
+    def normalize(cls, local_part, domain):
+        local_part = local_part.split('--')[0]
+        return '{0}@{1}'.format(local_part, domain)
+
+# returns bob@cipher.com
+normalize('Bob--Test@cipher.com', default_normalizer=MyNormalizer)
+```

--- a/email_normalizer/__init__.py
+++ b/email_normalizer/__init__.py
@@ -52,7 +52,7 @@ def _get_mx_servers(domain):
         return []
 
 
-def _get_normalizer(domain, resolve):
+def _get_normalizer(domain, resolve, default_normalizer):
     if domain in _domain_normalizers:
         return _domain_normalizers[domain]
 
@@ -62,13 +62,13 @@ def _get_normalizer(domain, resolve):
                 if mx.endswith(service_domain):
                     return normalizer
 
-    return DefaultNormalizer
+    return default_normalizer or DefaultNormalizer
 
 
-def normalize(email, resolve=True):
+def normalize(email, resolve=True, default_normalizer=None):
     local_part, domain = email.lower().split('@')
 
-    return _get_normalizer(domain, resolve).normalize(local_part, domain)
+    return _get_normalizer(domain, resolve, default_normalizer).normalize(local_part, domain)
 
 
 _load_domains()

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@ import sys
 import mock
 
 from email_normalizer import normalize, _get_mx_servers, _load_domains
+from email_normalizer import BaseNormalizer
 
 
 class NormalizerTest(unittest.TestCase):
@@ -25,6 +26,14 @@ class NormalizerTest(unittest.TestCase):
 
     def test_default(self):
         self.assertEqual(normalize('test@domain.com', resolve=False), 'test@domain.com')
+
+    def test_override_default_normalizer(self):
+        class MyNormalizer(BaseNormalizer):
+            @classmethod
+            def normalize(cls, local_part, domain):
+                local_part = local_part.split('+')[0]
+                return '{0}@{1}'.format(local_part, domain)
+        self.assertEqual(normalize('foo+123@bar.com', resolve=False, default_normalizer=MyNormalizer), 'foo@bar.com')
 
     def test_duplicated_domains(self):
         with mock.patch('email_normalizer.google.GoogleNormalizer.domains', ['samedomain.com']), \


### PR DESCRIPTION
Our use case is that we would like to see the default behavior of email normalization be to remove sub-addressing w/ the '+' operator. This implementation of overriding the default normalizer allows us to easily accept the risk of assuming that behavior while keeping the default behavior intact.

Would love to hear any feedback you have and iterate on either this PR or the other one I opened (#1). 

Thanks for open sourcing this repo! 
